### PR TITLE
PIN-3600-3: Increase akka connection pool size

### DIFF
--- a/attributes-loader/src/main/resources/akka.conf
+++ b/attributes-loader/src/main/resources/akka.conf
@@ -2,4 +2,22 @@ akka {
   coordinated-shutdown {
     exit-jvm = on
   }
+
+  http {
+    server {
+      pipelining-limit = 128 # default 1
+      pipelining-limit = ${?PIPELINING_LIMIT}
+      backlog = 100 # default 100
+      backlog = ${?BACKLOG_SIZE}
+    }
+
+    host-connection-pool {
+      max-connections = 16
+      max-connections = ${?CONNECTION_POOL_MAX_CONNECTIONS}
+      min-connections = 2
+      min-connections = ${?CONNECTION_POOL_MIN_CONNECTIONS}
+      max-open-requests = 256
+      max-open-requests = ${?CONNECTION_POOL_MAX_OPEN_REQUESTS}
+    }
+  }
 }

--- a/attributes-loader/src/main/resources/akka.conf
+++ b/attributes-loader/src/main/resources/akka.conf
@@ -4,13 +4,6 @@ akka {
   }
 
   http {
-    server {
-      pipelining-limit = 128 # default 1
-      pipelining-limit = ${?PIPELINING_LIMIT}
-      backlog = 100 # default 100
-      backlog = ${?BACKLOG_SIZE}
-    }
-
     host-connection-pool {
       max-connections = 16
       max-connections = ${?CONNECTION_POOL_MAX_CONNECTIONS}


### PR DESCRIPTION
The current execution stops with
`Error: Exceeded configured max-open-requests value of [32]`
and it is triggered from the job, not the called process (which already has these settings).
